### PR TITLE
Add missing <cstdint> includes where GCC 13.1 complained.

### DIFF
--- a/base/logging.h
+++ b/base/logging.h
@@ -7,6 +7,7 @@
 
 #include <errno.h>
 
+#include <cstdint>
 #include <limits>
 #include <sstream>
 #include <string>

--- a/base/strings/utf_string_conversion_utils.h
+++ b/base/strings/utf_string_conversion_utils.h
@@ -5,6 +5,7 @@
 #ifndef MINI_CHROMIUM_BASE_STRINGS_UTF_STRING_CONVERSION_UTILS_H_
 #define MINI_CHROMIUM_BASE_STRINGS_UTF_STRING_CONVERSION_UTILS_H_
 
+#include <cstdint>
 #include <string>
 
 namespace base {


### PR DESCRIPTION
Two includes required for GCC 13.1 to pass compilation for me.

Scanning the code there are more places where explicit includes are missing, but they are being caught indirectly through other includes. 