### PR TITLE
Fix compile for GCC 13: add missing <cstdint> includes

### DIFF
--- a/base/logging.h
+++ b/base/logging.h
@@ -10,6 +10,7 @@
 #include <limits>
 #include <sstream>
 #include <string>
+#include <cstdint>
 
 #include "base/check.h"
 #include "base/check_op.h"

--- a/base/strings/utf_string_conversion_utils.h
+++ b/base/strings/utf_string_conversion_utils.h
@@ -6,6 +6,7 @@
 #define MINI_CHROMIUM_BASE_STRINGS_UTF_STRING_CONVERSION_UTILS_H_
 
 #include <string>
+#include <cstdint>
 
 namespace base {
 


### PR DESCRIPTION
Fix for gcc 13.  More includes required thanks to recent changes.